### PR TITLE
fix php notice "array to string conversion"

### DIFF
--- a/file/lib/system/command/AbstractSuspensionCommand.class.php
+++ b/file/lib/system/command/AbstractSuspensionCommand.class.php
@@ -94,7 +94,7 @@ abstract class AbstractSuspensionCommand extends AbstractRestrictedCommand {
 		
 		$ph = new \chat\system\permission\PermissionHandler();
 		if (static::IS_GLOBAL) {
-			WCF::getSession()->checkPermissions((array) 'mod.chat.canG'.static::SUSPENSION_TYPE);
+			WCF::getSession()->checkPermissions(array('mod.chat.canG'.static::SUSPENSION_TYPE));
 		}
 		else {
 			if (!WCF::getSession()->getPermission('mod.chat.canG'.static::SUSPENSION_TYPE)) {


### PR DESCRIPTION
if a user hasn't the permission 'admin.chat.canManageSuspensions' and will made an g*-command, the system prints an php-notice, because if you have an constant and a text you aren't able to use `(array)`-casting
